### PR TITLE
Build all missing tags

### DIFF
--- a/tags_compare.py
+++ b/tags_compare.py
@@ -1,0 +1,23 @@
+import json
+import sys
+import urllib2
+
+REPO_NAME = 'dockerswarm/dind'
+URL = (
+    'https://hub.docker.com/v2/repositories'
+    '/{0}/tags/?page=1&page_size=250'.format(
+        REPO_NAME
+    )
+)
+
+
+def main(github_tags):
+    github_tags = github_tags.split()
+    res = urllib2.urlopen(URL)
+    hub_tags = json.loads(res.read())
+    hub_tags = [t['name'] for t in hub_tags['results']]
+    for gh_t in github_tags:
+        if gh_t not in hub_tags:
+            print(gh_t)
+
+main(sys.argv[1])


### PR DESCRIPTION
Because 1.12.4 was released after 1.13.0-rc*, the current `ci.sh` script never builds 1.12.4.
This aims to remedy the situation with the help of a simple python script that compares github tags with a list of tags retrieved from the Docker Hub API. 