### PR TITLE
Use `dockerd` in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ TEST_HOST=tcp://0.0.0.0:2375
 docker run -d --privileged \
     --name $BUILD_ID \
     $DOCKER_IMAGE \
-    docker daemon -H $TEST_HOST $DOCKER_DAEMON_ARGS
+    dockerd -H $TEST_HOST $DOCKER_DAEMON_ARGS
 
 
 function on_exit() {


### PR DESCRIPTION
`docker daemon` command doesn't work anymore with 17.06

Follow-up to #2 

cc @dnephin 